### PR TITLE
test: use `t.Setenv` to set env vars

### DIFF
--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"os"
 	"path"
 	"sniffer/pkg/config"
 	v1 "sniffer/pkg/config/v1"
@@ -53,10 +52,7 @@ func TestInt8ToStr(t *testing.T) {
 
 func TestCheckPrerequisites(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(config.ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", config.ConfigEnvVar, err)
-	}
+	t.Setenv(config.ConfigEnvVar, configPath)
 
 	cfg := config.GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,10 +22,7 @@ func TestConfig(t *testing.T) {
 	}
 	{
 		configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-		err := os.Setenv(ConfigEnvVar, configPath)
-		if err != nil {
-			t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-		}
+		t.Setenv(ConfigEnvVar, configPath)
 
 		cfg := GetConfigurationConfigContext()
 		configData, err := cfg.GetConfigurationReader()
@@ -57,7 +54,7 @@ func TestConfig(t *testing.T) {
 		}
 	}
 	{
-		os.Setenv(ConfigEnvVar, "kuku")
+		t.Setenv(ConfigEnvVar, "kuku")
 		cfg := GetConfigurationConfigContext()
 		_, err := cfg.GetConfigurationReader()
 		if err == nil || !strings.Contains(err.Error(), ErrConfigurationFileNotValid) {
@@ -105,7 +102,7 @@ func TestGetConfigurationReader(t *testing.T) {
 	}
 	defer os.Remove(cfgFilePath)
 
-	os.Setenv(ConfigEnvVar, cfgFilePath)
+	t.Setenv(ConfigEnvVar, cfgFilePath)
 	reader, err = cfg.GetConfigurationReader()
 	if err != nil {
 		t.Errorf("unexpected error while getting reader: %v", err)
@@ -118,10 +115,7 @@ func TestGetConfigurationReader(t *testing.T) {
 func TestParseConfiguration(t *testing.T) {
 
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	cfg := GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()
@@ -168,10 +162,7 @@ func TestParseConfiguration(t *testing.T) {
 
 func TestIsFalcoEbpfEngineMock(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -218,10 +209,7 @@ func TestIsFalcoEbpfEngineMock(t *testing.T) {
 
 func TestGetFalcoKernelObjPath(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -243,10 +231,7 @@ func TestGetFalcoKernelObjPath(t *testing.T) {
 
 func TestGetEbpfEngineLoaderPath(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -268,10 +253,7 @@ func TestGetEbpfEngineLoaderPath(t *testing.T) {
 
 func TestGetUpdateDataPeriodMock(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -293,10 +275,7 @@ func TestGetUpdateDataPeriodMock(t *testing.T) {
 
 func TestGetSniffingMaxTimesMock(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -318,10 +297,7 @@ func TestGetSniffingMaxTimesMock(t *testing.T) {
 
 func TestIsRelevantCVEServiceEnabledMock(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -343,10 +319,7 @@ func TestIsRelevantCVEServiceEnabledMock(t *testing.T) {
 
 func TestGetNodeName(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -368,10 +341,7 @@ func TestGetNodeName(t *testing.T) {
 
 func TestGetClusterName(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -393,10 +363,7 @@ func TestGetClusterName(t *testing.T) {
 
 func TestGetNamespace(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -418,10 +385,7 @@ func TestGetNamespace(t *testing.T) {
 
 func TestGetContainerName(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -443,10 +407,7 @@ func TestGetContainerName(t *testing.T) {
 
 func TestGetBackgroundContextURL(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()
@@ -457,7 +418,7 @@ func TestGetBackgroundContextURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseConfiguration failed with err %v", err)
 	}
-	os.Setenv("OTEL_COLLECTOR_SVC", "URLcontext")
+	t.Setenv("OTEL_COLLECTOR_SVC", "URLcontext")
 
 	expected := "URLcontext"
 	config.data.SetBackgroundContextURL()
@@ -470,10 +431,7 @@ func TestGetBackgroundContextURL(t *testing.T) {
 
 func TestGetAccountID(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", ConfigEnvVar, err)
-	}
+	t.Setenv(ConfigEnvVar, configPath)
 
 	config := GetConfigurationConfigContext()
 	configData, err := config.GetConfigurationReader()

--- a/pkg/config/v1/config_data_test.go
+++ b/pkg/config/v1/config_data_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 	"time"
 )
@@ -132,7 +131,7 @@ func TestConfigData_GetClusterName(t *testing.T) {
 
 func TestConfigData_SetNodeName(t *testing.T) {
 	expectedName := "node-1"
-	_ = os.Setenv(nodeNameEnvVar, expectedName)
+	t.Setenv(nodeNameEnvVar, expectedName)
 	c := &ConfigData{}
 	c.SetNodeName()
 	if c.NodeData.Name != expectedName {
@@ -142,7 +141,7 @@ func TestConfigData_SetNodeName(t *testing.T) {
 
 func TestConfigData_SetNamespace(t *testing.T) {
 	expectedName := "namespace-1"
-	_ = os.Setenv(NamespaceEnvVar, expectedName)
+	t.Setenv(NamespaceEnvVar, expectedName)
 	c := &ConfigData{}
 	c.SetNamespace()
 	if c.Namespace != expectedName {
@@ -152,7 +151,7 @@ func TestConfigData_SetNamespace(t *testing.T) {
 
 func TestConfigData_SetContainerName(t *testing.T) {
 	expectedName := "cont-1"
-	_ = os.Setenv(ContainerNameEnvVar, expectedName)
+	t.Setenv(ContainerNameEnvVar, expectedName)
 	c := &ConfigData{}
 	c.SetContainerName()
 	if c.ContainerName != expectedName {
@@ -162,7 +161,7 @@ func TestConfigData_SetContainerName(t *testing.T) {
 
 func TestConfigData_SetBackgroundContextURL(t *testing.T) {
 	expectedName := "URL-1"
-	_ = os.Setenv("OTEL_COLLECTOR_SVC", expectedName)
+	t.Setenv("OTEL_COLLECTOR_SVC", expectedName)
 	c := &ConfigData{}
 	c.SetBackgroundContextURL()
 	if c.telemetryURL != expectedName {

--- a/pkg/conthandler/container_aggregator_test.go
+++ b/pkg/conthandler/container_aggregator_test.go
@@ -1,7 +1,6 @@
 package conthandler
 
 import (
-	"os"
 	"path"
 	"sniffer/pkg/config"
 	configV1 "sniffer/pkg/config/v1"
@@ -26,10 +25,7 @@ const (
 
 func TestContAggregator(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(config.ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env ConfigEnvVar with err %v", err)
-	}
+	t.Setenv(config.ConfigEnvVar, configPath)
 
 	cfg := config.GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()

--- a/pkg/conthandler/container_main_handler_test.go
+++ b/pkg/conthandler/container_main_handler_test.go
@@ -2,7 +2,6 @@ package conthandler
 
 import (
 	"context"
-	"os"
 	"path"
 	"sniffer/pkg/config"
 	configV1 "sniffer/pkg/config/v1"
@@ -22,10 +21,7 @@ const (
 
 func TestContMainHandler(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(config.ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env ConfigEnvVar with err %v", err)
-	}
+	t.Setenv(config.ConfigEnvVar, configPath)
 
 	cfg := config.GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()

--- a/pkg/conthandler/container_watcher_test.go
+++ b/pkg/conthandler/container_watcher_test.go
@@ -1,7 +1,6 @@
 package conthandler
 
 import (
-	"os"
 	"path"
 	"sniffer/pkg/config"
 	configV1 "sniffer/pkg/config/v1"
@@ -49,10 +48,7 @@ func (client *k8sFakeClient) GetWatcher() (watch.Interface, error) {
 
 func TestContWatcher(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(config.ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env ConfigEnvVar with err %v", err)
-	}
+	t.Setenv(config.ConfigEnvVar, configPath)
 
 	cfg := config.GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()

--- a/pkg/ebpfeng/falco_sniffer_engine_test.go
+++ b/pkg/ebpfeng/falco_sniffer_engine_test.go
@@ -1,7 +1,6 @@
 package ebpfeng
 
 import (
-	"os"
 	"path"
 	"sniffer/pkg/config"
 	v1 "sniffer/pkg/config/v1"
@@ -131,10 +130,7 @@ func TestCreateSyscallFilterString(t *testing.T) {
 
 func TestCreateFalcoEbpfEngine(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(config.ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", config.ConfigEnvVar, err)
-	}
+	t.Setenv(config.ConfigEnvVar, configPath)
 
 	cfg := config.GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()
@@ -154,10 +150,7 @@ func TestCreateFalcoEbpfEngine(t *testing.T) {
 
 func TestEbpfEngineCMDWithParams(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(config.ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", config.ConfigEnvVar, err)
-	}
+	t.Setenv(config.ConfigEnvVar, configPath)
 
 	cfg := config.GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()
@@ -193,10 +186,7 @@ func TestEbpfEngineCMDWithParams(t *testing.T) {
 
 func TestStartEbpfEngine(t *testing.T) {
 	configPath := path.Join(utils.CurrentDir(), "..", "..", "configuration", "ConfigurationFile.json")
-	err := os.Setenv(config.ConfigEnvVar, configPath)
-	if err != nil {
-		t.Fatalf("failed to set env ConfigEnvVar with err %v", err)
-	}
+	t.Setenv(config.ConfigEnvVar, configPath)
 
 	cfg := config.GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()

--- a/pkg/event_data_storage/accumulator_test.go
+++ b/pkg/event_data_storage/accumulator_test.go
@@ -1,7 +1,6 @@
 package accumulator
 
 import (
-	"os"
 	"sniffer/pkg/config"
 	v1 "sniffer/pkg/config/v1"
 	evData "sniffer/pkg/ebpfev/v1"
@@ -15,10 +14,7 @@ const (
 )
 
 func TestFullAccumulatorFlow(t *testing.T) {
-	err := os.Setenv(config.ConfigEnvVar, "../../configuration/ConfigurationFile.json")
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", config.ConfigEnvVar, err)
-	}
+	t.Setenv(config.ConfigEnvVar, "../../configuration/ConfigurationFile.json")
 
 	cfg := config.GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()
@@ -46,10 +42,7 @@ func TestFullAccumulatorFlow(t *testing.T) {
 }
 
 func TestFullAccumulatorFlowAndAllOtherSmallFunctions(t *testing.T) {
-	err := os.Setenv(config.ConfigEnvVar, "../../configuration/ConfigurationFile.json")
-	if err != nil {
-		t.Fatalf("failed to set env %s with err %v", config.ConfigEnvVar, err)
-	}
+	t.Setenv(config.ConfigEnvVar, "../../configuration/ConfigurationFile.json")
 
 	cfg := config.GetConfigurationConfigContext()
 	configData, err := cfg.GetConfigurationReader()


### PR DESCRIPTION
## Overview

Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

## How to Test

```
$ go test ./...
?   	sniffer	[no test files]
?   	sniffer/internal/version	[no test files]
?   	sniffer/pkg/context	[no test files]
?   	sniffer/pkg/ebpfev	[no test files]
?   	sniffer/pkg/ebpfev/v1	[no test files]
?   	sniffer/pkg/storageclient	[no test files]
ok  	sniffer/internal/validator	0.014s
ok  	sniffer/pkg/config	0.010s
ok  	sniffer/pkg/config/v1	0.011s
ok  	sniffer/pkg/conthandler	25.045s
ok  	sniffer/pkg/conthandler/v1	0.027s
ok  	sniffer/pkg/ebpfeng	0.015s
ok  	sniffer/pkg/event_data_storage	5.020s
ok  	sniffer/pkg/sbom	0.037s
ok  	sniffer/pkg/sbom/v1	0.043s
ok  	sniffer/pkg/utils	0.013s
```